### PR TITLE
Experimental custom cancellation

### DIFF
--- a/Example/Example/App.swift
+++ b/Example/Example/App.swift
@@ -106,10 +106,12 @@ struct TimerView: View {
 
 // MARK: - First component
 
+
+
 struct FirstState {
   var timer = TimerState()
-  var second: SecondState?
-  var sheet: SheetState?
+  @Presented var second: SecondState?
+  @Presented var sheet: SheetState?
 }
 
 enum FirstAction {
@@ -162,15 +164,15 @@ let firstReducer = Reducer<FirstState, FirstAction, Void>.combine(
     }
   }
 )
-.presents(
+.presented(
   secondReducer,
-  state: \.second,
+  state: \.$second,
   action: /FirstAction.second,
   environment: { () }
 )
-.presents(
+.presented(
   sheetReducer,
-  state: \.sheet,
+  state: \.$sheet,
   action: /FirstAction.sheet,
   environment: { () }
 )
@@ -223,7 +225,7 @@ struct SecondState {
   }
 
   var timer = TimerState()
-  var next: Next?
+  @Presented var next: Next?
 }
 
 enum SecondAction {
@@ -278,23 +280,23 @@ let secondReducer = Reducer<SecondState, SecondAction, Void>.combine(
     }
   }
 )
-.presents(
+.presented(
   thirdReducer.pullback(
     state: /SecondState.Next.third,
     action: /.self,
     environment: { $0 }
   ),
-  state: \.next,
+  state: \.$next,
   action: /SecondAction.third,
   environment: { () }
 )
-.presents(
+.presented(
   fourthReducer.pullback(
     state: /SecondState.Next.fourth,
     action: /.self,
     environment: { $0 }
   ),
-  state: \.next,
+  state: \.$next,
   action: /SecondAction.fourth,
   environment: { () }
 )

--- a/Sources/ComposablePresentation/EffectCanceller.swift
+++ b/Sources/ComposablePresentation/EffectCanceller.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Combine
+import ComposableArchitecture
+
+protocol EffectCancelling {
+
+  func register<P: Publisher>(
+    _ publisher: P
+  ) -> Effect<P.Output, P.Failure>
+
+  func cancel<NewOutput, NewFailure>(
+    outputType: NewOutput.Type,
+    failureType: NewFailure.Type
+  ) -> Effect<NewOutput, NewFailure>
+}
+
+extension Effect {
+
+  func cancellable(with canceller: EffectCancelling) -> Effect {
+    canceller.register(self)
+  }
+
+  static func cancel<NewOutput, NewFailure>(
+    with canceller: EffectCancelling,
+    outputType: NewOutput.Type = NewOutput.self,
+    failureType: NewFailure.Type = NewFailure.self
+  ) -> Effect<NewOutput, NewFailure> {
+    canceller.cancel(outputType: outputType, failureType: failureType)
+  }
+}
+
+/// ID of cancellable effects. The name is for easier debugging.
+struct CancellationId: Hashable {
+  let id: AnyHashable
+  let name: String
+}
+
+extension CancellationId: CustomStringConvertible {
+  var description: String {
+    "CancellationId<\(id):\(name)>"
+  }
+}
+
+/// Performs cancellation by ID, delegating to the standard TCA implementation.
+struct IdentifiedCanceller: EffectCancelling {
+
+  let id: CancellationId
+
+  func register<P: Publisher>(_ publisher: P) -> Effect<P.Output, P.Failure> {
+    publisher
+      .eraseToEffect()
+      .cancellable(id: id)
+  }
+
+  func cancel<NewOutput, NewFailure>(
+    outputType: NewOutput.Type,
+    failureType: NewFailure.Type
+  ) -> Effect<NewOutput, NewFailure> {
+    .cancel(id: id)
+  }
+}
+
+/// Performs cancellation within a single scope.
+/// It also implements cancellation without thread synchronization.
+/// The ID is for debugging only.
+final class NonLockingScopedCanceller: EffectCancelling {
+
+  init(id: CancellationId) {
+    self.id = id
+  }
+
+  private let id: CancellationId
+  private var cancellables = Set<AnyCancellable>()
+
+  func register<P: Publisher>(_ publisher: P) -> Effect<P.Output, P.Failure> {
+    let downstream = PassthroughSubject<P.Output, P.Failure>()
+    let upstream = publisher.subscribe(downstream)
+    var cancellable: AnyCancellable!
+
+    cancellable = AnyCancellable {
+      downstream.send(completion: .finished)
+      upstream.cancel()
+      self.cancellables.remove(cancellable)
+    }
+
+    cancellables.insert(cancellable)
+
+    return downstream.handleEvents(
+      receiveCompletion: { _ in cancellable.cancel() },
+      receiveCancel: cancellable.cancel
+    )
+      .eraseToEffect()
+  }
+
+  func cancel<NewOutput, NewFailure>(
+    outputType: NewOutput.Type,
+    failureType: NewFailure.Type
+  ) -> Effect<NewOutput, NewFailure> {
+    .fireAndForget {
+      self.cancellables.forEach { $0.cancel() }
+      self.cancellables = .init()
+    }
+  }
+}

--- a/Sources/ComposablePresentation/Reducer+PresentedKeyPath.swift
+++ b/Sources/ComposablePresentation/Reducer+PresentedKeyPath.swift
@@ -41,6 +41,9 @@ extension Reducer {
           state[keyPath: toLocalState].hadState = false
         }
         return shouldCancel
+      },
+      canceller: { state in
+          state[keyPath: toLocalState].canceller
       }
     )
   }
@@ -58,6 +61,12 @@ public struct Presented<State> {
 
   public init(wrappedValue: State?) {
     self.wrappedValue = wrappedValue
+    self.canceller = NonLockingScopedCanceller(
+      id: CancellationId(
+        id: UUID(),
+        name: String(describing: type(of: wrappedValue))
+      )
+    )
   }
 
   public var wrappedValue: State? {
@@ -72,6 +81,7 @@ public struct Presented<State> {
   }
 
   fileprivate var hadState: Bool = false
+  fileprivate var canceller: NonLockingScopedCanceller
 }
 
 fileprivate extension Presented {

--- a/Sources/ComposablePresentation/Reducer+PresentsCasePath.swift
+++ b/Sources/ComposablePresentation/Reducer+PresentsCasePath.swift
@@ -17,7 +17,11 @@ extension Reducer {
     action toLocalAction: CasePath<Action, LocalAction>,
     environment toLocalEnvironment: @escaping (Environment) -> LocalEnvironment
   ) -> Self {
-    combined(
+    let id = CancellationId(
+      id: UUID(),
+      name: String(describing: toLocalAction)
+    )
+    return combined(
       with: localReducer.pullback(
         state: toLocalState,
         action: toLocalAction,
@@ -28,6 +32,9 @@ extension Reducer {
       },
       cancelEffects: { state in
         toLocalState.extract(from: state) == nil
+      },
+      canceller: { _ in
+        IdentifiedCanceller(id: id)
       }
     )
   }

--- a/Sources/ComposablePresentation/Reducer+PresentsKeyPath.swift
+++ b/Sources/ComposablePresentation/Reducer+PresentsKeyPath.swift
@@ -21,7 +21,11 @@ extension Reducer {
     action toLocalAction: CasePath<Action, LocalAction>,
     environment toLocalEnvironment: @escaping (Environment) -> LocalEnvironment
   ) -> Self {
-    combined(
+    let id = CancellationId(
+      id: UUID(),
+      name: String(describing: toLocalAction)
+    )
+    return combined(
       with: localReducer.optional(breakpointOnNil: breakpointOnNil).pullback(
         state: toLocalState,
         action: toLocalAction,
@@ -38,6 +42,9 @@ extension Reducer {
         }
 #endif
         return shouldCancel
+      },
+      canceller: { _ in
+        IdentifiedCanceller(id: id)
       }
     )
   }

--- a/Tests/ComposablePresentationTests/ReducerCombinedTests.swift
+++ b/Tests/ComposablePresentationTests/ReducerCombinedTests.swift
@@ -49,6 +49,9 @@ final class ReducerCombinedTests: XCTestCase {
       cancelEffects: { state in
         self.didCallCancelEffectsOnState.append(state)
         return self.shouldCancelChildEffect
+      },
+      canceller: { _ in
+          IdentifiedCanceller(id: CancellationId(id: 0, name: "test"))
       }
     )
   }


### PR DESCRIPTION
## Summary

This extends  #rcarver/swift-composable-presentation:optimize-presents to optimize cancellation. In TCA cancellation has a lock around it and we're curious how expensive that is.

## What was done

- [x] Use the property wrapper to hold onto cancellation references
- [x] Continue using standard cancellation for non-property wrapper version

Another benefit of storing cancellation references in the property wrapper is that no state is created in the reducer. This can be problematic if using a reducer multiple times in an app.
